### PR TITLE
Add freshman page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -96,6 +96,7 @@ function sidebar() {
         text: '校园',
         items: [
           { text: '校内服务', link: '/campus' },
+          { text: '新生入门', link: '/campus/freshman' },
           { text: '社团组织', link: '/campus/clubs' },
         ]
       },

--- a/docs/campus/freshman.md
+++ b/docs/campus/freshman.md
@@ -10,6 +10,10 @@ links:
     link: https://meredith2328.github.io/freshdan/#/
     icon: https://fduguidebook.com/icons/fudan-blue.png
     desc: 复旦新生一站式信息平台
+  - text: 2025复旦大学新生攻略手册
+    link: https://docs.qq.com/sheet/DR0RSUWxTd0tGTE1q?tab=22tuz7
+    icon: https://fduguidebook.com/icons/qqdoc.jpg
+    desc: 复旦新生，请查收这份最全新生攻略！
 ---
 
 <script setup lang="ts">
@@ -25,3 +29,4 @@ import LinkList from "/.vitepress/components/unique/LinkList.vue";
 ## 搜索索引
 
 - Freshdan：复旦新生一站式信息平台
+- 2025复旦大学新生攻略手册：复旦新生，请查收这份最全新生攻略！

--- a/docs/campus/freshman.md
+++ b/docs/campus/freshman.md
@@ -1,0 +1,27 @@
+---
+prev:
+  text: 校内服务
+  link: /campus
+next:
+  text: 社团组织
+  link: /campus/clubs
+links:
+  - text: Freshdan
+    link: https://meredith2328.github.io/freshdan/#/
+    icon: https://fduguidebook.com/icons/fudan-blue.png
+    desc: 复旦新生一站式信息平台
+---
+
+<script setup lang="ts">
+import LinkList from "/.vitepress/components/unique/LinkList.vue";
+</script>
+
+# 新生入门
+
+---
+
+<LinkList :links="$frontmatter.links" />
+
+## 搜索索引
+
+- Freshdan：复旦新生一站式信息平台

--- a/docs/campus/index.md
+++ b/docs/campus/index.md
@@ -4,8 +4,8 @@
 # 这里先定义一个简单的链接列表，后续可按需扩展为多组
 prev: false
 next:
-  text: 社团组织
-  link: /campus/clubs
+  text: 新生入门
+  link: /campus/freshman
 
 links:
   - text: eHall
@@ -44,8 +44,8 @@ links:
     link: https://docs.qq.com/sheet/DR0RSUWxTd0tGTE1q?tab=22tuz7
     icon: https://fduguidebook.com/icons/qqdoc.jpg
     desc: 复旦新生，请查收这份最全新生攻略！
-  - text: 复旦大学请假条，ppt模板
-    link: https://github.com/FDUGuideBook/nav-site/tree/main/docs/public/files/templates
+  - text: 复旦大学ppt模板
+    link: https://github.com/JinnyWong/FudanPPT
     icon: https://fduguidebook.com/icons/Github-Dark.svg
     desc: 一些你或许没有的模板
 innerLinks: 
@@ -86,7 +86,7 @@ import LinkList from "/.vitepress/components/unique/LinkList.vue";
 - 体育管理综合查询系统：成绩、刷段情况查询，理论考试
 - 缴费平台：缴纳学费、住宿费、医保等
 - 2025复旦大学新生攻略手册：复旦新生，请查收这份最全新生攻略！
-- 复旦大学请假条，ppt模板：一些你或许没有的模板
+- 复旦大学ppt模板：一些你或许没有的模板
 - 课表查询：查询全校日期-教室-课程对应情况
 - 考试座位表查询：暗中观察所有同学的考试
 - 正版软件：学校提供的正版软件获取与使用说明

--- a/docs/campus/index.md
+++ b/docs/campus/index.md
@@ -40,10 +40,6 @@ links:
     link: https://cwgl.fudan.edu.cn/payment/
     icon: https://fduguidebook.com/icons/fudan-blue.png
     desc: 缴纳学费、住宿费、医保等
-  - text: 2025复旦大学新生攻略手册
-    link: https://docs.qq.com/sheet/DR0RSUWxTd0tGTE1q?tab=22tuz7
-    icon: https://fduguidebook.com/icons/qqdoc.jpg
-    desc: 复旦新生，请查收这份最全新生攻略！
   - text: 复旦大学ppt模板
     link: https://github.com/JinnyWong/FudanPPT
     icon: https://fduguidebook.com/icons/Github-Dark.svg
@@ -85,7 +81,6 @@ import LinkList from "/.vitepress/components/unique/LinkList.vue";
 - 选课系统（本科）：选课事务
 - 体育管理综合查询系统：成绩、刷段情况查询，理论考试
 - 缴费平台：缴纳学费、住宿费、医保等
-- 2025复旦大学新生攻略手册：复旦新生，请查收这份最全新生攻略！
 - 复旦大学ppt模板：一些你或许没有的模板
 - 课表查询：查询全校日期-教室-课程对应情况
 - 考试座位表查询：暗中观察所有同学的考试

--- a/docs/study/index.md
+++ b/docs/study/index.md
@@ -76,6 +76,7 @@ import LinkList from "/.vitepress/components/unique/LinkList.vue";
 
 <LinkList :links="$frontmatter.webLinks" />
 
+
 ## 搜索索引
 
 - FDU Sharing：复旦课程资料开放平台


### PR DESCRIPTION
This pull request introduces a new "新生入门" (Freshman Guide) section to the campus documentation and reorganizes related resources to improve navigation and clarity for new students. The most important changes are as follows:

**Navigation and Structure Updates:**

* Added a new sidebar entry and dedicated page for "新生入门" (`/campus/freshman`), making it easier for freshmen to find relevant information. [[1]](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deR99) [[2]](diffhunk://#diff-daca8cf0c213e4a7536ed14c18456a9f75ab0f9ec459c99ee321d81c883ab6d0R1-R32)
* Updated the navigation flow in `/campus/index.md` so that the "next" link now points to the new "新生入门" page instead of "社团组织".

**Resource Organization:**

* Moved the "2025复旦大学新生攻略手册" (2025 Fudan University Freshman Guide) link from the general campus resources to the new freshman page, ensuring that freshman-specific resources are grouped together. [[1]](diffhunk://#diff-4655e6e52527c16a7cd09ac4f95234bd50cf1199ee58fb9b7a2969083d93f4f1L43-R44) [[2]](diffhunk://#diff-daca8cf0c213e4a7536ed14c18456a9f75ab0f9ec459c99ee321d81c883ab6d0R1-R32)
* Updated the resource list to clarify that the PPT template link now points to "复旦大学ppt模板" and adjusted the description accordingly. [[1]](diffhunk://#diff-4655e6e52527c16a7cd09ac4f95234bd50cf1199ee58fb9b7a2969083d93f4f1L43-R44) [[2]](diffhunk://#diff-4655e6e52527c16a7cd09ac4f95234bd50cf1199ee58fb9b7a2969083d93f4f1L88-R84)

**Minor Content Adjustments:**

* Added a search index section and improved formatting for resource lists, enhancing usability for students seeking specific information. [[1]](diffhunk://#diff-daca8cf0c213e4a7536ed14c18456a9f75ab0f9ec459c99ee321d81c883ab6d0R1-R32) [[2]](diffhunk://#diff-49b041b28e65bfb55cf17e4077431466de15c0ada8a4e87d655db9679dac88e3R79)